### PR TITLE
Pin the pytorch versions to be compatible with TensorRT-LLM

### DIFF
--- a/docker/base-image/install-deps.sh
+++ b/docker/base-image/install-deps.sh
@@ -44,7 +44,7 @@ bash install_cmake.sh
 source $ENV
 bash install_ccache.sh
 # later on TensorRT-LLM will force reinstall this version anyways
-pip3 install --extra-index-url https://download.pytorch.org/whl/cu121 torch
+pip3 install --extra-index-url https://download.pytorch.org/whl/cu121 torch==2.1.0
 bash install_tensorrt.sh
 bash install_polygraphy.sh
 source $ENV

--- a/docker/scripts/setup-whisperfusion.sh
+++ b/docker/scripts/setup-whisperfusion.sh
@@ -8,7 +8,7 @@ apt update
 apt install ffmpeg portaudio19-dev -y
 
 ## Install torchaudio matching the PyTorch from the base image
-pip install --extra-index-url https://download.pytorch.org/whl/cu121 torchaudio
+pip install --extra-index-url https://download.pytorch.org/whl/cu121 torchaudio==2.1.0
 
 ## Install all the other dependencies normally
 pip install -r requirements.txt


### PR DESCRIPTION
When building the docker images from scratch on a google cloud instance, I ran into an issue with the pytorch version installed by pip not being compatible with TensorRT-LLM. Following this issue thread https://github.com/NVIDIA/TensorRT-LLM/issues/808 I was able to resole the issue by introducing these version pins to the respective Docker build scripts.