### PR TITLE
Pin SileroVAD to v4.0

### DIFF
--- a/docker/scripts/setup-whisperfusion.sh
+++ b/docker/scripts/setup-whisperfusion.sh
@@ -19,6 +19,6 @@ huggingface-cli download charactr/vocos-encodec-24khz
 mkdir -p /root/.cache/torch/hub/checkpoints/
 curl -L -o /root/.cache/torch/hub/checkpoints/encodec_24khz-d7cc33bc.th https://dl.fbaipublicfiles.com/encodec/v0/encodec_24khz-d7cc33bc.th
 mkdir -p /root/.cache/whisper-live/
-curl -L -o /root/.cache/whisper-live/silero_vad.onnx https://github.com/snakers4/silero-vad/raw/master/files/silero_vad.onnx
+curl -L -o /root/.cache/whisper-live/silero_vad.onnx https://github.com/snakers4/silero-vad/raw/v4.0/files/silero_vad.onnx
 
 python3 -c 'from transformers.utils.hub import move_cache; move_cache()'

--- a/whisper_live/vad.py
+++ b/whisper_live/vad.py
@@ -98,7 +98,7 @@ class VoiceActivityDetection():
         return stacked.cpu()
 
     @staticmethod
-    def download(model_url="https://github.com/snakers4/silero-vad/raw/master/files/silero_vad.onnx"):
+    def download(model_url="https://github.com/snakers4/silero-vad/raw/v4.0/files/silero_vad.onnx"):
         target_dir = os.path.expanduser("~/.cache/whisper-live/")
 
         # Ensure the target directory exists


### PR DESCRIPTION
[SileroVAD](https://github.com/snakers4/silero-vad) updated their model which requires updating the VAD inference. For now, sticking to the older version of the model.

Fixes https://github.com/collabora/WhisperFusion/issues/54